### PR TITLE
Restrict aws robotics dependencies

### DIFF
--- a/health_metric_collector/package.xml
+++ b/health_metric_collector/package.xml
@@ -18,11 +18,11 @@
   <depend>std_msgs</depend>
   <depend>message_generation</depend>
   <depend>ros_monitoring_msgs</depend>
-  <depend>aws_common</depend>
-  <depend>aws_ros1_common</depend>
+  <depend version_lt='2.0.0'>aws_common</depend>
+  <depend version_lt='2.0.0'>aws_ros1_common</depend>
   
   <exec_depend>message_runtime</exec_depend>
-  <exec_depend>cloudwatch_metrics_collector</exec_depend>
+  <exec_depend version_lt='2.0.0'>cloudwatch_metrics_collector</exec_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>google-mock</test_depend>


### PR DESCRIPTION
*Description of changes:*
Sets the aws-robotics depends less than 2.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
