### PR TITLE
Update to use non-legacy ParameterReader API

### DIFF
--- a/health_metric_collector/include/health_metric_collector/collect_and_publish.h
+++ b/health_metric_collector/include/health_metric_collector/collect_and_publish.h
@@ -30,10 +30,9 @@ public:
    * @param mg the metric manager that publishes collected metrics.
    * @param c a list of metrics collectors.
    */
-  CollectAndPublish(MetricManagerInterface & mg, const std::vector<MetricCollectorInterface *> & c)
-  : mg_(mg), collectors_(c)
-  {
-  }
+  CollectAndPublish(ros_monitoring_msgs::MetricManagerInterface & mg,
+                    const std::vector<MetricCollectorInterface *> & c)
+    : mg_(mg), collectors_(c) {}
 
   /**
    * @brief activates all collectors and then publishes the metrics.
@@ -49,6 +48,6 @@ public:
   }
 
 private:
-  MetricManagerInterface & mg_;
+  ros_monitoring_msgs::MetricManagerInterface & mg_;
   const std::vector<MetricCollectorInterface *> & collectors_;
 };

--- a/health_metric_collector/include/health_metric_collector/cpu_metric_collector.h
+++ b/health_metric_collector/include/health_metric_collector/cpu_metric_collector.h
@@ -20,7 +20,6 @@
 #include <health_metric_collector/metric_collector.h>
 #include <health_metric_collector/metric_manager.h>
 
-using namespace ros_monitoring_msgs;
 
 /**
  * collects cpu usage metric.
@@ -33,7 +32,8 @@ public:
    *
    * @param m metric manager which creates and aggregates metrics.
    */
-  CPUMetricCollector(MetricManagerInterface & m) : MetricCollectorInterface(m) {}
+  CPUMetricCollector(ros_monitoring_msgs::MetricManagerInterface & m)
+    : MetricCollectorInterface(m) {}
 
   /**
    * @brief activates metrics collection.

--- a/health_metric_collector/include/health_metric_collector/metric_collector.h
+++ b/health_metric_collector/include/health_metric_collector/metric_collector.h
@@ -26,7 +26,7 @@ public:
   /**
    * @brief Constructor.
    */
-  MetricCollectorInterface(MetricManagerInterface & m) : mgr_(m) {}
+  MetricCollectorInterface(ros_monitoring_msgs::MetricManagerInterface & m) : mgr_(m) {}
 
   /**
    * @brief callback for collecting metrics.
@@ -37,5 +37,5 @@ protected:
   /**
    * @brief creates metric entries and publishes them.
    */
-  MetricManagerInterface & mgr_;
+  ros_monitoring_msgs::MetricManagerInterface & mgr_;
 };

--- a/health_metric_collector/include/health_metric_collector/metric_manager.h
+++ b/health_metric_collector/include/health_metric_collector/metric_manager.h
@@ -21,7 +21,6 @@
 
 #include <vector>
 
-using namespace ros_monitoring_msgs;
 
 namespace ros_monitoring_msgs {
 
@@ -78,4 +77,5 @@ private:
   MetricList mlist_;
   ros_monitoring_msgs::MetricData dimensions_;
 };
+
 }  // namespace ros_monitoring_msgs

--- a/health_metric_collector/include/health_metric_collector/sys_info_collector.h
+++ b/health_metric_collector/include/health_metric_collector/sys_info_collector.h
@@ -18,7 +18,6 @@
 #include <health_metric_collector/metric_collector.h>
 #include <health_metric_collector/metric_manager.h>
 
-using namespace ros_monitoring_msgs;
 
 /**
  * @brief collects metrics from sysinfo.
@@ -29,7 +28,8 @@ using namespace ros_monitoring_msgs;
 class SysInfoCollector : public MetricCollectorInterface
 {
 public:
-  SysInfoCollector(MetricManagerInterface & m) : MetricCollectorInterface(m) {}
+  SysInfoCollector(ros_monitoring_msgs::MetricManagerInterface & m)
+    : MetricCollectorInterface(m) {}
 
   void Collect() override final;
 

--- a/health_metric_collector/package.xml
+++ b/health_metric_collector/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>health_metric_collector</name>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
   <description>The health_metric_collector package</description>
   <url>http://wiki.ros.org/health_metric_collector</url>
 

--- a/health_metric_collector/package.xml
+++ b/health_metric_collector/package.xml
@@ -22,7 +22,6 @@
   <depend>aws_ros1_common</depend>
   
   <exec_depend>message_runtime</exec_depend>
-  <exec_depend>cloudwatch_metrics_collector</exec_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>google-mock</test_depend>

--- a/health_metric_collector/src/collector.cpp
+++ b/health_metric_collector/src/collector.cpp
@@ -25,6 +25,10 @@
 
 #include <vector>
 
+using namespace Aws::Client;
+using namespace ros_monitoring_msgs;
+
+
 #define DEFAULT_INTERVAL_SEC 5
 #define TOPIC_BUFFER_SIZE 1000
 #define INTERVAL_PARAM_NAME "interval"
@@ -36,21 +40,20 @@
 #define INTERVAL_PARAM_NAME "interval"
 #define METRICS_TOPIC_NAME "metrics"
 
-using namespace ros_monitoring_msgs;
 
 int main(int argc, char ** argv)
 {
   ros::init(argc, argv, DEFAULT_NODE_NAME);
 
-  auto param_reader = std::make_shared<Aws::Client::Ros1NodeParameterReader>();
+  auto param_reader = std::make_shared<Ros1NodeParameterReader>();
 
   // get interval param
   double interval = DEFAULT_INTERVAL_SEC;
-  param_reader->ReadDouble(INTERVAL_PARAM_NAME, interval);
+  param_reader->ReadParam(ParameterPath(INTERVAL_PARAM_NAME), interval);
 
   // get robot id
   std::string robot_id = DEFAULT_ROBOT_ID;
-  param_reader->ReadStdString(ROBOT_ID_DIMENSION, robot_id);
+  param_reader->ReadParam(ParameterPath(ROBOT_ID_DIMENSION), robot_id);
 
   // advertise
   ros::NodeHandle public_nh;

--- a/health_metric_collector/src/cpu_metric_collector.cpp
+++ b/health_metric_collector/src/cpu_metric_collector.cpp
@@ -20,7 +20,11 @@
 #include <chrono>
 #include <thread>
 
+using namespace ros_monitoring_msgs;
+
+
 #define BASE_METRIC_NAME "cpu_usage_"
+
 
 void CPUMetricCollector::Collect()
 {

--- a/health_metric_collector/src/metric_manager.cpp
+++ b/health_metric_collector/src/metric_manager.cpp
@@ -16,6 +16,9 @@
 #include <health_metric_collector/metric_manager.h>
 #include <ros_monitoring_msgs/MetricDimension.h>
 
+using namespace ros_monitoring_msgs;
+
+
 MetricData ros_monitoring_msgs::MetricManager::CreateMetric() const
 {
   MetricData md;

--- a/health_metric_collector/src/sys_info_collector.cpp
+++ b/health_metric_collector/src/sys_info_collector.cpp
@@ -20,7 +20,11 @@
 #include <fstream>
 #include <iostream>
 
+using namespace ros_monitoring_msgs;
+
+
 #define MEGA (1000000)
+
 
 void SysInfoCollector::Collect()
 {

--- a/health_metric_collector/test/health_metric_collector_test.cpp
+++ b/health_metric_collector/test/health_metric_collector_test.cpp
@@ -24,7 +24,9 @@
 
 #include <vector>
 
+
 namespace ros_monitoring_msgs {
+
 class MockMetricManager : public MetricManagerInterface
 {
 public:
@@ -43,13 +45,17 @@ public:
   MockMetricCollector(MetricManagerInterface & m) : MetricCollectorInterface(m) {}
   MOCK_METHOD0(Collect, void());
 };
-}  // namespace ros_monitoring_msgs
 
+} // namespace ros_monitoring_msgs
+
+
+using namespace ros_monitoring_msgs;
 using ::testing::Return;
+
 
 TEST(CollectorSuite, Child)
 {
-  ros_monitoring_msgs::MockMetricManager mg;
+  MockMetricManager mg;
 
   std::vector<MetricCollectorInterface *> collectors;
   MockMetricCollector mc(mg);
@@ -69,7 +75,7 @@ TEST(CollectorSuite, Child)
 
 TEST(CollectorSuite, sysinfo)
 {
-  ros_monitoring_msgs::MockMetricManager mg;
+  MockMetricManager mg;
   MetricData md;
   ON_CALL(mg, CreateMetric()).WillByDefault(Return(md));
 
@@ -80,7 +86,7 @@ TEST(CollectorSuite, sysinfo)
 
 TEST(CollectorSuite, cpu_usage_0)
 {
-  ros_monitoring_msgs::MockMetricManager mg;
+  MockMetricManager mg;
   MetricData md;
   ON_CALL(mg, CreateMetric()).WillByDefault(Return(md));
 
@@ -92,7 +98,7 @@ TEST(CollectorSuite, cpu_usage_0)
 
 TEST(CollectorSuite, cpu_usage_1)
 {
-  ros_monitoring_msgs::MockMetricManager mg;
+  MockMetricManager mg;
   MetricData md;
   ON_CALL(mg, CreateMetric()).WillByDefault(Return(md));
 


### PR DESCRIPTION
*Description of changes:*

We have decided to remove the legacy portions of the ParameterReader API. ParameterReader will now only accept ParameterPath objects for addressing parameters. Calls to ReadParam need to be updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
