### PR TITLE
Use standard CMake macros for adding gtest/gmock tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ notifications:
 env:
   global:
     - GITHUB_ACCOUNT=aws-robotics
-    # uncomment PACKAGE_NAME to build unit tests - REQUIRED if you'd like to run unit tests using colcon
-    - PACKAGE_NAME=health_metric_collector
+    # uncomment PACKAGE_NAMES to build unit tests - REQUIRED if you'd like to run unit tests using colcon
+    - PACKAGE_NAMES=health_metric_collector
   matrix:
     # define DOWNSTREAM_GITHUB_REPO=name-of-your-repo if you'd like to trigger downstream repos' travis builds
     - ROS_DISTRO=kinetic ROS_VERSION=1

--- a/health_metric_collector/CMakeLists.txt
+++ b/health_metric_collector/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(health_metric_collector)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++17)
 set(CMAKE_CXX_STANDARD 14)
 
 ## Find catkin macros and libraries
@@ -73,10 +72,15 @@ if(CATKIN_ENABLE_TESTING)
       ${catkin_INCLUDE_DIRS}
       ${GMOCK_INCLUDE_DIRS}
     )
-    target_link_libraries(test_health_metric_collector ${catkin_LIBRARIES} collector_lib ${GMOCK_BOTH_LIBRARIES})
+    target_link_libraries(test_health_metric_collector
+      collector_lib
+      ${catkin_LIBRARIES}
+      ${GMOCK_BOTH_LIBRARIES}
+    )
   else()
     include_directories(/usr/include/gmock /usr/src/gmock)
-    add_library(${PROJECT_NAME}_libgmock /usr/src/gmock/src/gmock-all.cc)
+    add_library(${PROJECT_NAME}_libgmock SHARED /usr/src/gmock/src/gmock-all.cc)
+
     add_rostest_gtest(test_health_metric_collector
       test/test_health_metric_collector.test
       test/health_metric_collector_test.cpp
@@ -85,6 +89,10 @@ if(CATKIN_ENABLE_TESTING)
       PRIVATE include
       ${catkin_INCLUDE_DIRS}
     )
-    target_link_libraries(test_health_metric_collector ${catkin_LIBRARIES} collector_lib ${PROJECT_NAME}_libgmock)
+    target_link_libraries(test_health_metric_collector
+      collector_lib
+      ${catkin_LIBRARIES}
+      ${PROJECT_NAME}_libgmock
+    )
   endif()
 endif()

--- a/health_metric_collector/package.xml
+++ b/health_metric_collector/package.xml
@@ -10,7 +10,6 @@
 
   <license>Apache 2.0</license>
 
-
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>roscpp</depend>
@@ -23,6 +22,7 @@
 
   <exec_depend>message_runtime</exec_depend>
 
-  <test_depend>rostest</test_depend>
+  <test_depend>gtest</test_depend>
   <test_depend>google-mock</test_depend>
+  <test_depend>rostest</test_depend>
 </package>


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.