### PR TITLE
Fix calculation of memory metrics

### DIFF
--- a/health_metric_collector/src/sys_info_collector.cpp
+++ b/health_metric_collector/src/sys_info_collector.cpp
@@ -23,20 +23,18 @@
 using namespace ros_monitoring_msgs;
 
 
-#define MEGA (1000000)
+#define MEGA (1048576.0)
 
 
 void SysInfoCollector::Collect()
 {
   // Obtain system statistics
-  struct sysinfo si
-  {
-  };
+  struct sysinfo si = {0};
   sysinfo(&si);
 
   AddMetric("system_uptime", si.uptime, MetricData::UNIT_SEC);
-  AddMetric("free_ram", si.freeram / MEGA, MetricData::UNIT_MEGABYTES);
-  AddMetric("total_ram", si.totalram / MEGA, MetricData::UNIT_MEGABYTES);
+  AddMetric("free_ram", si.freeram * si.mem_unit / MEGA, MetricData::UNIT_MEGABYTES);
+  AddMetric("total_ram", si.totalram * si.mem_unit / MEGA, MetricData::UNIT_MEGABYTES);
   AddMetric("process_count", si.procs, MetricData::UNIT_NONE);
 }
 


### PR DESCRIPTION
*Issue:* Possibly fixes https://forums.aws.amazon.com/thread.jspa?threadID=317955

*Description of changes:*

There are issues with how memory metrics data is currently collected by this ROS package. The pull request makes the following changes:
- In operating systems conventions, megabytes (MB) actually mean mebibytes (MiB)
- Make use of `struct sysinfo`'s `mem_unit` field, because the unit might not always be 1 byte
- Allow decimal / non-integer conversion of bytes to megabytes / mebibytes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.